### PR TITLE
Remove usage of deprecated React APIs

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types';
 
 const isCollinear = (p1, p2, p3) => {
     return (p1.y - p2.y) * (p1.x - p3.x) == (p1.y - p3.y) * (p1.x - p2.x);
@@ -11,42 +12,40 @@ const moveTo = (b, a, r) => {
     return {x: a.x + unitVector.x * r, y: a.y + unitVector.y * r};
 }
 
-export const PathLine = React.createClass({
-    render: function(){
-        let {points, r, ...other} = this.props;
-        const path = points
-                        .slice(1)
-                        .reduce((acc, p, i, points) => { 
-                                    let next = points[i + 1];
-                                    let prev = acc[acc.length - 1];
-                                    
-                                    if (next && !isCollinear(prev.point, p, next)) {
-                                        let before = moveTo(prev.point, p, r);
-                                        let after = moveTo(next, p, r);
-                                        return acc.concat({
-                                            point:p,
-                                            s:`L ${before.x} ${before.y} S ${p.x} ${p.y} ${after.x} ${after.y} `
-                                        })
-                                    } else { 
-                                        return acc.concat({
-                                            point:p,
-                                            s:`L ${p.x} ${p.y} `
-                                        })
-                                    };
-                                }
-                                , [{
-                                    point: this.props.points[0], 
-                                    s: `M ${this.props.points[0].x} ${this.props.points[0].y} `
-                                }])
-                        .map(p => p.s)
-                        .join();
-        return (
-            <path d={path} {...other} />
-        )
-    }
-})
+export const PathLine = () => {
+    let {points, r, ...other} = this.props;
+    const path = points
+                    .slice(1)
+                    .reduce((acc, p, i, points) => {
+                                let next = points[i + 1];
+                                let prev = acc[acc.length - 1];
 
-PathLine.propTypes = { 
-  points: React.PropTypes.array.isRequired, 
-  r: React.PropTypes.number.isRequired
+                                if (next && !isCollinear(prev.point, p, next)) {
+                                    let before = moveTo(prev.point, p, r);
+                                    let after = moveTo(next, p, r);
+                                    return acc.concat({
+                                        point:p,
+                                        s:`L ${before.x} ${before.y} S ${p.x} ${p.y} ${after.x} ${after.y} `
+                                    })
+                                } else {
+                                    return acc.concat({
+                                        point:p,
+                                        s:`L ${p.x} ${p.y} `
+                                    })
+                                };
+                            }
+                            , [{
+                                point: this.props.points[0],
+                                s: `M ${this.props.points[0].x} ${this.props.points[0].y} `
+                            }])
+                    .map(p => p.s)
+                    .join();
+    return (
+        <path d={path} {...other} />
+    )
+};
+
+PathLine.propTypes = {
+  points: PropTypes.array.isRequired,
+  r: PropTypes.number.isRequired
 }

--- a/index.jsx
+++ b/index.jsx
@@ -12,8 +12,7 @@ const moveTo = (b, a, r) => {
     return {x: a.x + unitVector.x * r, y: a.y + unitVector.y * r};
 }
 
-export const PathLine = () => {
-    let {points, r, ...other} = this.props;
+export const PathLine = ({ points, r, ...other }) => {
     const path = points
                     .slice(1)
                     .reduce((acc, p, i, points) => {
@@ -35,8 +34,8 @@ export const PathLine = () => {
                                 };
                             }
                             , [{
-                                point: this.props.points[0],
-                                s: `M ${this.props.points[0].x} ${this.props.points[0].y} `
+                                point: points[0],
+                                s: `M ${points[0].x} ${points[0].y} `
                             }])
                     .map(p => p.s)
                     .join();

--- a/package.json
+++ b/package.json
@@ -50,5 +50,8 @@
       "react",
       "stage-2"
     ]
+  },
+  "dependencies": {
+    "prop-types": "^15.5.8"
   }
 }


### PR DESCRIPTION
- Replace ```createClass``` by a stateless component
- Replace ```React.PropTypes``` by ```PropTypes``` from the ```prop-types``` package